### PR TITLE
IEventStore should allow saving non aggregate events

### DIFF
--- a/src/OpenEventSourcing/Domain/ConcurrencyException.cs
+++ b/src/OpenEventSourcing/Domain/ConcurrencyException.cs
@@ -4,10 +4,10 @@ namespace OpenEventSourcing.Domain
 {
     public class ConcurrencyException : Exception
     {
-        public ConcurrencyException(Guid aggregateId, int expectedVersion, int actualVersion)
+        public ConcurrencyException(Guid aggregateId, long expectedVersion, long actualVersion)
             : base(BuildErrorMessage(aggregateId, expectedVersion, actualVersion)) { }
 
-        private static string BuildErrorMessage(Guid aggregateId, int expectedVersion, int actualVersion)
+        private static string BuildErrorMessage(Guid aggregateId, long expectedVersion, long actualVersion)
             => $"Concurrency exception | Aggregate: {aggregateId} | Expected version: {expectedVersion} | Actual version: {actualVersion}";
     }
 }

--- a/src/OpenEventSourcing/Events/IEventStore.cs
+++ b/src/OpenEventSourcing/Events/IEventStore.cs
@@ -10,7 +10,7 @@ namespace OpenEventSourcing.Events
         Task<Page> GetEventsAsync(long offset);
         Task<IEnumerable<IEvent>> GetEventsAsync(Guid aggregateId);
         Task<IEnumerable<IEvent>> GetEventsAsync(Guid aggregateId, long offset);
-        Task SaveAsync<TState>(Aggregate<TState> aggregate, int expectedVersion)
-            where TState : IAggregateState, new();
+        Task SaveAsync(IEnumerable<IEvent> events);
+        Task<long> CountAsync(Guid aggregateId);
     }
 }


### PR DESCRIPTION
Previously the IEventStore interface SaveAsync would take in an aggregate to save the events. In reality the logic for aggregates should have been part of the aggregate repository itself and just pass the events through the store rather than passing the aggregate itself. This prevented non aggregate events from being saved through the IEventStore abstraction when a consumer may not have been using the aggregate implementations (e.g. non event-sourced behaviour)