### PR TITLE
Support for additional rabbit mq configuration options

### DIFF
--- a/samples/OpenEventSourcing.Samples.RabbitMq/Program.cs
+++ b/samples/OpenEventSourcing.Samples.RabbitMq/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenEventSourcing.Extensions;
+using OpenEventSourcing.RabbitMQ;
 using OpenEventSourcing.RabbitMQ.Extensions;
 using OpenEventSourcing.Serialization.Json.Extensions;
 
@@ -27,7 +28,7 @@ namespace OpenEventSourcing.Samples.RabbitMq
                                        .UseExchange(e =>
                                        {
                                            e.WithName($"sample-exchange");
-                                           e.UseExchangeType("topic");
+                                           e.UseTopicExchangeType();
                                        })
                                        .AddSubscription(s =>
                                        {

--- a/src/OpenEventSourcing.RabbitMQ/ExchangeTypes.cs
+++ b/src/OpenEventSourcing.RabbitMQ/ExchangeTypes.cs
@@ -1,0 +1,10 @@
+﻿namespace OpenEventSourcing.RabbitMQ
+{
+    public static class ExchangeTypes
+    {
+        public static readonly string Direct = "direct";
+        public static readonly string Fanout = "fanout";
+        public static readonly string Headers = "headers";
+        public static readonly string Topic = "topic";
+    }
+}

--- a/src/OpenEventSourcing.RabbitMQ/Extensions/RabbitMqExchangeOptionsExtensions.cs
+++ b/src/OpenEventSourcing.RabbitMQ/Extensions/RabbitMqExchangeOptionsExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace OpenEventSourcing.RabbitMQ.Extensions
+{
+    public static class RabbitMqExchangeOptionsExtensions
+    {
+        public static RabbitMqExchangeOptions UseTopicExchangeType(this RabbitMqExchangeOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            options.UseExchangeType(ExchangeTypes.Topic);
+
+            return options;
+        }
+        public static RabbitMqExchangeOptions UseDirectExchangeType(this RabbitMqExchangeOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            options.UseExchangeType(ExchangeTypes.Direct);
+
+            return options;
+        }
+        public static RabbitMqExchangeOptions UseFanoutExchangeType(this RabbitMqExchangeOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            options.UseExchangeType(ExchangeTypes.Fanout);
+
+            return options;
+        }
+        public static RabbitMqExchangeOptions UseHeadersExchangeType(this RabbitMqExchangeOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            options.UseExchangeType(ExchangeTypes.Headers);
+
+            return options;
+        }
+    }
+}

--- a/src/OpenEventSourcing.RabbitMQ/RabbitMqExchangeOptions.cs
+++ b/src/OpenEventSourcing.RabbitMQ/RabbitMqExchangeOptions.cs
@@ -4,8 +4,10 @@ namespace OpenEventSourcing.RabbitMQ
 {
     public class RabbitMqExchangeOptions
     {
-        internal string Name { get; set; }
-        internal string Type { get; set; }
+        public string Name { get; internal set; }
+        public string Type { get; internal set; }
+        public bool ShouldAutoDelete { get; internal set; }
+        public bool Durable { get; internal set; }
 
         public RabbitMqExchangeOptions WithName(string exchange)
         {
@@ -16,12 +18,34 @@ namespace OpenEventSourcing.RabbitMQ
 
             return this;
         }
+
         public RabbitMqExchangeOptions UseExchangeType(string exchangeType)
         {
             if (string.IsNullOrEmpty(exchangeType))
                 throw new ArgumentException($"'{nameof(exchangeType)}' cannot be null or empty.", nameof(exchangeType));
 
             Type = exchangeType;
+
+            return this;
+        }
+        /// <summary>
+        /// Sets the exchange to auto delete once all queues have finished using the exchange. Defaults to false.
+        /// </summary>
+        /// <returns></returns>
+        public RabbitMqExchangeOptions AutoDelete()
+        {
+            ShouldAutoDelete = true;
+
+            return this;
+        }
+        /// <summary>
+        /// Sets the exchange to be durable. Durable exchanges remain active when a server restarts. Non-durable exchanges (transient exchanges) are purged if/when a server restarts. Defaults to true.
+        /// </summary>
+        /// <param name="durable"></param>
+        /// <returns></returns>
+        public RabbitMqExchangeOptions WithDurable(bool durable)
+        {
+            Durable = durable;
 
             return this;
         }

--- a/src/OpenEventSourcing.RabbitMQ/RabbitMqSubscription.cs
+++ b/src/OpenEventSourcing.RabbitMQ/RabbitMqSubscription.cs
@@ -6,12 +6,16 @@ namespace OpenEventSourcing.RabbitMQ
 {
     public class RabbitMqSubscription
     {
-        internal string Name { get; set; }
-        internal IList<Type> Events { get; }
+        public string Name { get; internal set; }
+        public IList<Type> Events { get; internal set; }
+        public bool ShouldAutoDelete { get; internal set; }
+        public bool Durable { get; internal set; }
 
         public RabbitMqSubscription()
         {
             Events = new List<Type>();
+            ShouldAutoDelete = false;
+            Durable = true;
         }
 
         public RabbitMqSubscription UseName(string queueName)
@@ -30,6 +34,27 @@ namespace OpenEventSourcing.RabbitMQ
 
             if (!Events.Contains(type))
                 Events.Add(type);
+
+            return this;
+        }
+        /// <summary>
+        /// Sets the subscription to auto delete once all consumers disconnect. Defaults to false.
+        /// </summary>
+        /// <returns></returns>
+        public RabbitMqSubscription AutoDelete()
+        {
+            ShouldAutoDelete = true;
+
+            return this;
+        }
+        /// <summary>
+        /// Sets the subscription to be durable. Durable queues remain active when a server restarts. Non-durable queues (transient queues) are purged if/when a server restarts. Defaults to true.
+        /// </summary>
+        /// <param name="durable"></param>
+        /// <returns></returns>
+        public RabbitMqSubscription WithDurable(bool durable)
+        {
+            Durable = durable;
 
             return this;
         }

--- a/src/OpenEventSourcing.RabbitMQ/Subscriptions/DefaultSubscriptionManager.cs
+++ b/src/OpenEventSourcing.RabbitMQ/Subscriptions/DefaultSubscriptionManager.cs
@@ -26,14 +26,14 @@ namespace OpenEventSourcing.RabbitMQ.Subscriptions
         public async Task ConfigureAsync()
         {
             if (!await _client.ExchangeExistsAsync(name: _options.Value.Exchange.Name))
-                await _client.CreateExchangeAsync(name: _options.Value.Exchange.Name, exchangeType: _options.Value.Exchange.Type);
+                await _client.CreateExchangeAsync(name: _options.Value.Exchange.Name, exchangeType: _options.Value.Exchange.Type, durable: _options.Value.Exchange.Durable, autoDelete: _options.Value.Exchange.ShouldAutoDelete);
 
             var managementApiEnabled = _options.Value.ManagementApi != null;
 
             foreach (var subscription in _options.Value.Subscriptions)
             {
                 if (!await _client.QueueExistsAsync(name: subscription.Name))
-                    await _client.CreateQueueAsync(name: subscription.Name);
+                    await _client.CreateQueueAsync(name: subscription.Name, durable: subscription.Durable, autoDelete: subscription.ShouldAutoDelete);
 
                 if (managementApiEnabled)
                 {

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/ExchangeTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/ExchangeTests.cs
@@ -33,6 +33,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.Connection
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/FinalizerTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/FinalizerTests.cs
@@ -44,6 +44,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.Connection
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();
@@ -85,6 +86,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.Connection
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();
@@ -128,6 +130,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.Connection
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/QueueTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/QueueTests.cs
@@ -32,6 +32,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.Connection
                           {
                               e.WithName("test-exchange");
                               e.UseExchangeType("topic");
+                              e.AutoDelete();
                           });
                      })
                      .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/SubscriptionTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/Connection/SubscriptionTests.cs
@@ -33,6 +33,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.Connection
                           {
                               e.WithName("test-exchange");
                               e.UseExchangeType("topic");
+                              e.AutoDelete();
                           });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/ConnectionFactory/ConnectionTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/ConnectionFactory/ConnectionTests.cs
@@ -33,6 +33,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();
@@ -70,6 +71,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/ConnectionFactory/ConstructorTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/ConnectionFactory/ConstructorTests.cs
@@ -35,6 +35,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();
@@ -90,6 +91,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/ConnectionPool/ConnectionTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Connections/ConnectionPool/ConnectionTests.cs
@@ -32,6 +32,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.ConnectionPool
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();
@@ -95,6 +96,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Connections.ConnectionPool
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Management/ConstructorTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Management/ConstructorTests.cs
@@ -31,6 +31,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Management
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Management/ExchangeTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Management/ExchangeTests.cs
@@ -32,6 +32,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Management
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Management/QueueTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Management/QueueTests.cs
@@ -31,6 +31,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Management
                           {
                               e.WithName("test-exchange");
                               e.UseExchangeType("topic");
+                              e.AutoDelete();
                           });
                      })
                      .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Management/SubscriptionTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Management/SubscriptionTests.cs
@@ -35,6 +35,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Management
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     }).AddJsonSerializers();
 
@@ -202,6 +203,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Management
                          {
                              e.WithName(exchangeName);
                              e.UseExchangeType(exchangeType);
+                             e.AutoDelete();
                          });
 
                         o.UseManagementApi(m => 
@@ -252,6 +254,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Management
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
 
                         o.UseManagementApi(m => {
@@ -297,6 +300,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Management
                          {
                              e.WithName(exchangeName);
                              e.UseExchangeType(exchangeType);
+                             e.AutoDelete();
                          });
 
                         o.UseManagementApi(m => 

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Messages/MessageFactoryTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Messages/MessageFactoryTests.cs
@@ -30,6 +30,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Messages
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Queues/Client/PublishTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Queues/Client/PublishTests.cs
@@ -34,6 +34,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Queues.Client
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Queues/Receiver/ReceiverTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Queues/Receiver/ReceiverTests.cs
@@ -98,16 +98,19 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Queues.Receiver
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          })
                          .AddSubscription(s =>
                          {
                              s.UseName($"receiver-queue-{Guid.NewGuid()}");
                              s.ForEvent<MultipleSampleReceiverEventOne>();
+                             s.AutoDelete();
                          })
                          .AddSubscription(s =>
                          {
                              s.UseName($"receiver-queue-{Guid.NewGuid()}");
                              s.ForEvent<MultipleSampleReceiverEventTwo>();
+                             s.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Queues/Sender/SendTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Queues/Sender/SendTests.cs
@@ -32,6 +32,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Queues.Sender
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/RabbitMqEventBus/ConstructorTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/RabbitMqEventBus/ConstructorTests.cs
@@ -29,6 +29,7 @@ namespace OpenEventSourcing.RabbitMQ.Tests.RabbitMqEventBus
                          {
                              e.WithName("test-exchange");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();

--- a/tests/OpenEventSourcing.RabbitMQ.Tests/Subscriptions/SubscriptionManager/ConfigureTests.cs
+++ b/tests/OpenEventSourcing.RabbitMQ.Tests/Subscriptions/SubscriptionManager/ConfigureTests.cs
@@ -42,10 +42,12 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Subscriptions.SubscriptionManager
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          })
                          .AddSubscription(s =>
                          {
                              s.UseName($"test-queue-{Guid.NewGuid()}");
+                             s.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();
@@ -85,10 +87,12 @@ namespace OpenEventSourcing.RabbitMQ.Tests.Subscriptions.SubscriptionManager
                          {
                              e.WithName($"test-exchange-{Guid.NewGuid()}");
                              e.UseExchangeType("topic");
+                             e.AutoDelete();
                          })
                          .AddSubscription(s =>
                          {
                              s.UseName($"test-queue-{Guid.NewGuid()}");
+                             s.AutoDelete();
                          });
                     })
                     .AddJsonSerializers();


### PR DESCRIPTION
Adds support for the following:

#### RabbitMqExchangeOptions

`AutoDelete`
`Durable(bool)`

#### RabbitMqQueueOptions

`AutoDelete`
`Durable(bool)`

